### PR TITLE
Use path.join instead of string interpolation

### DIFF
--- a/index.js
+++ b/index.js
@@ -135,7 +135,7 @@ try {
   /****************************************/
 
   const testPath = path.dirname(testProject);
-  const coverageFile = `${testPath}/${output}`;
+  const coverageFile = path.join(testPath, output);
 
 
   if (!fs.existsSync(coverageFile)) {


### PR DESCRIPTION
String interpolation causes issues with relative paths
![image](https://github.com/b3b00/coverlet-action/assets/124283324/14fc00e1-f4b0-4042-ad57-497f66d32ff8)
